### PR TITLE
Json logger

### DIFF
--- a/logger/config.go
+++ b/logger/config.go
@@ -5,7 +5,7 @@ const (
 	ProductionLevel  = "production"
 
 	// defaultLevel is the default logger level
-	defaultLevel = DevelopmentLevel
+	defaultLevel = ProductionLevel
 )
 
 // Config is a struct to configure logger


### PR DESCRIPTION
Set default logger to production one in order to use json encoder, not available with config